### PR TITLE
Refactor keyboardnav registration

### DIFF
--- a/src/fixtures/draw/draw.vue
+++ b/src/fixtures/draw/draw.vue
@@ -70,31 +70,79 @@ async function handleKeyboardShortcuts() {
     if (!(await iApi.fixture.isLoaded('keyboardnav'))) return;
     const keyboardNav = iApi.fixture.get('keyboardnav') as KeyboardnavAPI;
 
-    keyboardNav.registerNamespace('D', keyPressed => {
-        console.error(keyPressed, 'key pressed');
-        switch (keyPressed) {
-            case 'P':
-                drawStore.setActiveTool('point');
-                break;
-            case 'L':
-                drawStore.setActiveTool('polyline');
-                break;
-            case 'G':
-                drawStore.setActiveTool('polygon');
-                break;
-            case 'C':
-                drawStore.setActiveTool('circle');
-                break;
-            case 'R':
-                drawStore.setActiveTool('rectangle');
-                break;
-            case 'E':
-                drawStore.setActiveTool('edit');
-                break;
-            case 'ACTIVE':
-                break;
-        }
-        iApi.geo.map.esriView?.focus();
+    keyboardNav.register('D', {
+        name: {
+            en: 'Draw Tools',
+            fr: 'Outils de dessin'
+        },
+        keys: [
+            {
+                key: 'P',
+                description: {
+                    en: 'Draw a point',
+                    fr: 'Dessine un point'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('point');
+                    iApi.geo.map.esriView?.focus();
+                }
+            },
+            {
+                key: 'L',
+                description: {
+                    en: 'Draw a line',
+                    fr: 'Dessine une ligne'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('polyline');
+                    iApi.geo.map.esriView?.focus();
+                }
+            },
+            {
+                key: 'G',
+                description: {
+                    en: 'Draw a polygon',
+                    fr: 'Dessine un polygone'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('polygon');
+                    iApi.geo.map.esriView?.focus();
+                }
+            },
+            {
+                key: 'C',
+                description: {
+                    en: 'Draw a circle',
+                    fr: 'Dessine un cercle'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('circle');
+                    iApi.geo.map.esriView?.focus();
+                }
+            },
+            {
+                key: 'R',
+                description: {
+                    en: 'Draw a rectangle',
+                    fr: 'Dessine un rectangle'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('rectangle');
+                    iApi.geo.map.esriView?.focus();
+                }
+            },
+            {
+                key: 'E',
+                description: {
+                    en: 'Edit geometry',
+                    fr: 'Mode édition'
+                },
+                handler: () => {
+                    drawStore.setActiveTool('edit');
+                    iApi.geo.map.esriView?.focus();
+                }
+            }
+        ]
     });
 }
 

--- a/src/fixtures/keyboardnav/api/keyboardnav.ts
+++ b/src/fixtures/keyboardnav/api/keyboardnav.ts
@@ -1,5 +1,6 @@
 import { FixtureInstance } from '@/api';
 import { useKeyboardnavStore } from '../store/keyboardnav-store';
+import type { NamespaceRegistration } from '../store/keyboardnav-store';
 
 /**
  * @internal
@@ -8,14 +9,20 @@ export class KeyboardnavAPI extends FixtureInstance {
     private keyboardnavStore = useKeyboardnavStore(this.$vApp.$pinia);
 
     /**
-     * Register a namespace letter and its callback to handle shortcut events.
+     * Register a namespace letter and its keyboard options.
      *
-     * @param namespace Uppercase letter for this fixture's namespace.
-     * @param callback Called when namespace is activated (key undefined) or a shortcut key is pressed.
+     * @param namespace requested namespace letter.
+     * @param options registration object describing keys and handlers.
+     * @returns final namespace letter used for registration.
      */
-    registerNamespace(namespace: string, callback: (key?: string) => void): void {
+    register(namespace: string, options: NamespaceRegistration): string {
         const ns = namespace.toUpperCase();
-        this.keyboardnavStore.register(ns, callback);
+        const finalNs = this.keyboardnavStore.register(ns, options);
+        const key = `keyboardnav.ns.${finalNs}`;
+        Object.entries(options.name).forEach(([lang, val]) => {
+            (<any>this.$iApi.$i18n).mergeLocaleMessage(lang, { [key]: val });
+        });
+        return finalNs;
     }
 
     /** @internal */
@@ -33,19 +40,19 @@ export class KeyboardnavAPI extends FixtureInstance {
     private _handleKeyDown = (e: KeyboardEvent): void => {
         const key = e.key.toUpperCase();
         if (e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
-            if (key in this.keyboardnavStore.handlers) {
+            if (key in this.keyboardnavStore.namespaces) {
                 e.preventDefault();
-                this.keyboardnavStore.activate(key);
+                this.keyboardnavStore.activate(key, e);
             }
         } else if (!e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey && key.length === 1) {
             if (this.keyboardnavStore.activeNamespace) {
                 e.preventDefault();
-                this.keyboardnavStore.trigger(key);
+                this.keyboardnavStore.trigger(key, e);
             }
         }
     };
 
-    private _handleBlur = (): void => {
-        this.keyboardnavStore.deactivate();
+    private _handleBlur = (e?: Event): void => {
+        this.keyboardnavStore.deactivate(e as KeyboardEvent);
     };
 }

--- a/src/fixtures/keyboardnav/keyboardnav.vue
+++ b/src/fixtures/keyboardnav/keyboardnav.vue
@@ -1,16 +1,30 @@
 <template>
-    <div v-if="activeNamespace" class="ramp-keyboardnav-indicator" role="status" aria-live="assertive">
-        {{ $t('keyboardnav.activeNamespace', { ns: activeNamespace }) }}
+    <div
+        v-if="indicatorText"
+        class="ramp-keyboardnav-indicator"
+        role="status"
+        aria-live="assertive"
+    >
+        {{ indicatorText }}
     </div>
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useKeyboardnavStore } from './store/keyboardnav-store';
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 // grab store and expose its state
 const store = useKeyboardnavStore();
 const { activeNamespace } = storeToRefs(store);
+const { t } = useI18n();
+
+const indicatorText = computed(() => {
+    if (!activeNamespace.value) return '';
+    const name = t(`keyboardnav.ns.${activeNamespace.value}`);
+    return t('keyboardnav.activeNamespace', { name });
+});
 </script>
 
 <style scoped>

--- a/src/fixtures/keyboardnav/lang/lang.csv
+++ b/src/fixtures/keyboardnav/lang/lang.csv
@@ -1,2 +1,2 @@
 key,enValue,enValid,frValue,frValid
-keyboardnav.activeNamespace,Namespace Active: {ns},1,,0
+keyboardnav.activeNamespace,Namespace Active: {name},1,Espace de noms actif : {name},0

--- a/src/fixtures/keyboardnav/store/keyboardnav-store.ts
+++ b/src/fixtures/keyboardnav/store/keyboardnav-store.ts
@@ -1,52 +1,107 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue';
+import type { Ref } from 'vue';
+
+export interface KeyItem {
+    key: string;
+    description: Record<string, string>;
+    handler?: (e: KeyboardEvent) => void;
+}
+
+export interface NamespaceRegistration {
+    name: Record<string, string>;
+    keys: KeyItem[];
+    handler?: (key: string, e: KeyboardEvent) => void;
+    activeHandler?: (e: KeyboardEvent) => void;
+    deactiveHandler?: (e: KeyboardEvent) => void;
+}
 
 export interface KeyboardnavStore {
-    activeNamespace: string | null;
-    handlers: Record<string, (key?: string) => void>;
-    register: (namespace: string, callback: (key?: string) => void) => void;
+    activeNamespace: Ref<string | null>;
+    namespaces: Ref<Record<string, NamespaceRegistration>>;
+    register: (namespace: string, options: NamespaceRegistration) => string;
     unregister: (namespace: string) => void;
-    activate: (namespace: string) => void;
-    deactivate: () => void;
-    trigger: (key: string) => void;
+    activate: (namespace: string, e: KeyboardEvent) => void;
+    deactivate: (e?: KeyboardEvent) => void;
+    trigger: (key: string, e: KeyboardEvent) => void;
 }
 
 export const useKeyboardnavStore = defineStore('keyboardnav', () => {
     const activeNamespace = ref<string | null>(null);
-    const handlers = ref<Record<string, (key?: string) => void>>({});
+    const namespaces = ref<Record<string, NamespaceRegistration>>({});
 
-    function register(namespace: string, callback: (key?: string) => void): void {
-        handlers.value[namespace] = callback;
+    function findFreeLetter(): string | null {
+        const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+        for (const ch of alphabet) {
+            if (!namespaces.value[ch]) return ch;
+        }
+        return null;
+    }
+
+    function register(namespace: string, options: NamespaceRegistration): string {
+        let ns = namespace.toUpperCase();
+        if (namespaces.value[ns]) {
+            const free = findFreeLetter();
+            if (free) {
+                ns = free;
+            } else {
+                console.error('No available keyboard namespace letters');
+            }
+        }
+
+        if (!options.handler) {
+            for (const k of options.keys) {
+                if (!k.handler) {
+                    console.error(
+                        `Keyboardnav registration for ${ns} requires handlers for all keys or a parent handler`
+                    );
+                }
+            }
+        }
+
+        namespaces.value[ns] = options;
+        return ns;
     }
 
     function unregister(namespace: string): void {
         if (activeNamespace.value === namespace) {
             activeNamespace.value = null;
         }
-        delete handlers.value[namespace];
+        delete namespaces.value[namespace];
     }
 
-    function activate(namespace: string): void {
+    function activate(namespace: string, e: KeyboardEvent): void {
         activeNamespace.value = namespace;
-        handlers.value[namespace]?.('ACTIVE');
+        namespaces.value[namespace]?.activeHandler?.(e);
     }
 
-    function deactivate(): void {
-        handlers.value[activeNamespace.value!]?.('DEACTIVE');
+    function deactivate(e?: KeyboardEvent): void {
+        if (activeNamespace.value) {
+            namespaces.value[activeNamespace.value]?.deactiveHandler?.(e!);
+        }
         activeNamespace.value = null;
     }
 
-    function trigger(key: string): void {
-        handlers.value[activeNamespace.value ?? '']?.(key);
+    function trigger(key: string, e: KeyboardEvent): void {
+        const ns = activeNamespace.value;
+        if (!ns) return;
+        const options = namespaces.value[ns];
+        if (!options) return;
+        if (options.handler) {
+            options.handler(key, e);
+        } else {
+            const item = options.keys.find(k => k.key === key);
+            item?.handler?.(e);
+        }
     }
 
     return {
         activeNamespace,
-        handlers,
+        namespaces,
         register,
         unregister,
         activate,
         deactivate,
         trigger
-    };
+    } as KeyboardnavStore;
 });


### PR DESCRIPTION
## Summary
- implement new keyboardnav registration format
- update draw fixture to use per-key handlers
- show registered namespace name in keyboardnav indicator
- register namespace names with i18n

## Testing
- `npm run lint`
- `npm run ts:check` *(fails: many unrelated type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684091496ddc832c9cb9a3b177e11ba9