### PR TITLE
Improve keyboard help overlay

### DIFF
--- a/src/fixtures/keyboardnav/api/keyboardnav.ts
+++ b/src/fixtures/keyboardnav/api/keyboardnav.ts
@@ -22,25 +22,36 @@ export class KeyboardnavAPI extends FixtureInstance {
         Object.entries(options.name).forEach(([lang, val]) => {
             (<any>this.$iApi.$i18n).mergeLocaleMessage(lang, { [key]: val });
         });
+        options.keys.forEach(k => {
+            const kKey = `keyboardnav.key.${finalNs}.${k.key}`;
+            Object.entries(k.description).forEach(([lang, val]) => {
+                (<any>this.$iApi.$i18n).mergeLocaleMessage(lang, { [kKey]: val });
+            });
+        });
         return finalNs;
     }
 
     /** @internal */
     added(): void {
         this.$iApi.$rootEl?.addEventListener('keydown', (e: Event) => this._handleKeyDown(e as KeyboardEvent));
+        this.$iApi.$rootEl?.addEventListener('keyup', (e: Event) => this._handleKeyUp(e as KeyboardEvent));
         this.$iApi.$rootEl?.addEventListener('blur', this._handleBlur);
     }
 
     /** @internal */
     removed(): void {
         this.$iApi.$rootEl?.removeEventListener('keydown', (e: Event) => this._handleKeyDown(e as KeyboardEvent));
+        this.$iApi.$rootEl?.removeEventListener('keyup', (e: Event) => this._handleKeyUp(e as KeyboardEvent));
         this.$iApi.$rootEl?.removeEventListener('blur', this._handleBlur);
     }
 
     private _handleKeyDown = (e: KeyboardEvent): void => {
         const key = e.key.toUpperCase();
         if (e.shiftKey && !e.altKey && !e.ctrlKey && !e.metaKey) {
-            if (key in this.keyboardnavStore.namespaces) {
+            if (key === 'H' || e.key === '?') {
+                e.preventDefault();
+                this.keyboardnavStore.setHelpVisible(true);
+            } else if (key in this.keyboardnavStore.namespaces) {
                 e.preventDefault();
                 this.keyboardnavStore.activate(key, e);
             }
@@ -52,7 +63,15 @@ export class KeyboardnavAPI extends FixtureInstance {
         }
     };
 
+    private _handleKeyUp = (e: KeyboardEvent): void => {
+        const key = e.key.toUpperCase();
+        if (!e.shiftKey || key === 'H' || e.key === '?') {
+            this.keyboardnavStore.setHelpVisible(false);
+        }
+    };
+
     private _handleBlur = (e?: Event): void => {
         this.keyboardnavStore.deactivate(e as KeyboardEvent);
+        this.keyboardnavStore.setHelpVisible(false);
     };
 }

--- a/src/fixtures/keyboardnav/keyboardnav.vue
+++ b/src/fixtures/keyboardnav/keyboardnav.vue
@@ -1,5 +1,35 @@
 <template>
     <div
+        v-if="helpVisible"
+        class="ramp-keyboardnav-overlay fixed inset-0 flex items-center justify-center z-50"
+    >
+        <div
+            class="bg-black-75 text-white p-6 rounded-md max-w-md max-h-96 overflow-y-auto"
+            role="dialog"
+            aria-modal="true"
+            aria-live="polite"
+        >
+            <h2 class="text-lg font-bold mb-2">{{ t('keyboardnav.helpTitle') }}</h2>
+            <ul class="mb-2">
+                <li v-for="ns in namespaceList" :key="ns" class="mb-1">
+                    <span class="font-mono">SHIFT + {{ ns }}</span>:
+                    {{ t(`keyboardnav.ns.${ns}`) }}
+                </li>
+            </ul>
+            <div v-if="activeNamespace" class="pt-2 border-t border-white-75">
+                <h3 class="font-bold mb-1">
+                    {{ t('keyboardnav.keysTitle', { name: t(`keyboardnav.ns.${activeNamespace}`) }) }}
+                </h3>
+                <ul>
+                    <li v-for="item in activeKeys" :key="item.key" class="mb-1">
+                        <span class="font-mono">{{ item.key }}</span>:
+                        {{ t(`keyboardnav.key.${activeNamespace}.${item.key}`) }}
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+    <div
         v-if="indicatorText"
         class="ramp-keyboardnav-indicator"
         role="status"
@@ -15,15 +45,21 @@ import { useKeyboardnavStore } from './store/keyboardnav-store';
 import { computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-// grab store and expose its state
 const store = useKeyboardnavStore();
-const { activeNamespace } = storeToRefs(store);
+const { activeNamespace, namespaces, helpVisible } = storeToRefs(store);
 const { t } = useI18n();
 
 const indicatorText = computed(() => {
     if (!activeNamespace.value) return '';
     const name = t(`keyboardnav.ns.${activeNamespace.value}`);
     return t('keyboardnav.activeNamespace', { name });
+});
+
+const namespaceList = computed(() => Object.keys(namespaces.value));
+const activeKeys = computed(() => {
+    const ns = activeNamespace.value;
+    if (!ns) return [];
+    return namespaces.value[ns]?.keys || [];
 });
 </script>
 
@@ -38,5 +74,8 @@ const indicatorText = computed(() => {
     border-radius: 0.25rem;
     font-weight: bold;
     z-index: 1000;
+}
+.ramp-keyboardnav-overlay {
+    background-color: rgba(0, 0, 0, 0.4);
 }
 </style>

--- a/src/fixtures/keyboardnav/lang/lang.csv
+++ b/src/fixtures/keyboardnav/lang/lang.csv
@@ -1,2 +1,4 @@
 key,enValue,enValid,frValue,frValid
 keyboardnav.activeNamespace,Namespace Active: {name},1,Espace de noms actif : {name},0
+keyboardnav.helpTitle,Keyboard Shortcuts,1,Raccourcis clavier,1
+keyboardnav.keysTitle,Keys for {name},1,Raccourcis pour {name},1

--- a/src/fixtures/keyboardnav/store/keyboardnav-store.ts
+++ b/src/fixtures/keyboardnav/store/keyboardnav-store.ts
@@ -19,28 +19,33 @@ export interface NamespaceRegistration {
 export interface KeyboardnavStore {
     activeNamespace: Ref<string | null>;
     namespaces: Ref<Record<string, NamespaceRegistration>>;
+    helpVisible: Ref<boolean>;
     register: (namespace: string, options: NamespaceRegistration) => string;
     unregister: (namespace: string) => void;
     activate: (namespace: string, e: KeyboardEvent) => void;
     deactivate: (e?: KeyboardEvent) => void;
     trigger: (key: string, e: KeyboardEvent) => void;
+    setHelpVisible: (val: boolean) => void;
 }
 
 export const useKeyboardnavStore = defineStore('keyboardnav', () => {
     const activeNamespace = ref<string | null>(null);
     const namespaces = ref<Record<string, NamespaceRegistration>>({});
+    const helpVisible = ref<boolean>(false);
+
+    const RESERVED = ['H', '?'];
 
     function findFreeLetter(): string | null {
         const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
         for (const ch of alphabet) {
-            if (!namespaces.value[ch]) return ch;
+            if (!namespaces.value[ch] && !RESERVED.includes(ch)) return ch;
         }
         return null;
     }
 
     function register(namespace: string, options: NamespaceRegistration): string {
         let ns = namespace.toUpperCase();
-        if (namespaces.value[ns]) {
+        if (RESERVED.includes(ns) || namespaces.value[ns]) {
             const free = findFreeLetter();
             if (free) {
                 ns = free;
@@ -61,6 +66,10 @@ export const useKeyboardnavStore = defineStore('keyboardnav', () => {
 
         namespaces.value[ns] = options;
         return ns;
+    }
+
+    function setHelpVisible(val: boolean): void {
+        helpVisible.value = val;
     }
 
     function unregister(namespace: string): void {
@@ -98,10 +107,12 @@ export const useKeyboardnavStore = defineStore('keyboardnav', () => {
     return {
         activeNamespace,
         namespaces,
+        helpVisible,
         register,
         unregister,
         activate,
         deactivate,
-        trigger
+        trigger,
+        setHelpVisible
     } as KeyboardnavStore;
 });


### PR DESCRIPTION
## Summary
- improve keyboard navigation overlay design and functionality
- reserve `SHIFT + H` and `SHIFT + ?` namespaces
- expose key descriptions to i18n

## Testing
- `npm run ts:check` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840ab970fc4832cbe1e69fbb2201051